### PR TITLE
Fixed broken gestures when carousel is empty.

### DIFF
--- a/DemoApp/Views/Discovery/TrailListView.swift
+++ b/DemoApp/Views/Discovery/TrailListView.swift
@@ -191,7 +191,9 @@ class TrailListView: UIView {
 extension TrailListView : UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        trails?.count ?? 0
+        let count = trails?.count ?? 0
+        self.superview?.isUserInteractionEnabled = count > 0
+        return count
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {


### PR DESCRIPTION
Fixed issue when user can't zoom out or pan the map. This was happening, because of user interaction on empty carousel.